### PR TITLE
Don't error when Result is shadowed

### DIFF
--- a/codegen/src/windows_dll_impl.rs
+++ b/codegen/src/windows_dll_impl.rs
@@ -121,10 +121,10 @@ pub fn parse_extern_block(dll_name: &str, input: TokenStream) -> Result<proc_mac
                 let outer_return_type = if fallible_attr {
                     match &output {
                         ReturnType::Default => {
-                            quote! { -> Result<(), #crate_name::Error> }
+                            quote! { -> #crate_name::Result<(), #crate_name::Error> }
                         }
                         ReturnType::Type(_, ty) => {
-                            quote! { -> Result<#ty, #crate_name::Error> }
+                            quote! { -> #crate_name::Result<#ty, #crate_name::Error> }
                         }
                     }
                 } else {
@@ -149,13 +149,14 @@ pub fn parse_extern_block(dll_name: &str, input: TokenStream) -> Result<proc_mac
                     #vis enum #ident {}
                     impl #ident {
                         #[inline]
-                        unsafe fn ptr() -> Result<&'static unsafe #abi fn( #(#inputs),* ) #output, &'static #crate_name::Error> {
+                        unsafe fn ptr() -> #crate_name::Result<&'static unsafe #abi fn( #(#inputs),* ) #output, &'static #crate_name::Error> {
                             use {
-                                core::mem::transmute,
-                                windows_dll::{
+                                #crate_name::{
                                     load_dll_proc_name,
                                     load_dll_proc_ordinal,
                                     once_cell::sync::OnceCell,
+                                    core::mem::transmute,
+                                    Result,
                                 },
                             };
                             static FUNC_PTR: OnceCell<Result<unsafe #abi fn( #(#inputs),* ) #output, #crate_name::Error>> = OnceCell::new();
@@ -166,7 +167,7 @@ pub fn parse_extern_block(dll_name: &str, input: TokenStream) -> Result<proc_mac
                             }).as_ref()
                         }
                         #[inline]
-                        unsafe fn ptr_clone_err() -> Result<&'static unsafe #abi fn( #(#inputs),* ) #output, #crate_name::Error> {
+                        unsafe fn ptr_clone_err() -> #crate_name::Result<&'static unsafe #abi fn( #(#inputs),* ) #output, #crate_name::Error> {
                             Self::ptr().map_err(|err| err.clone())
                         }
                         pub fn exists() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub use {
     windows_dll_codegen::dll,
     once_cell,
+    core,
+    core::result::Result,
 };
 
 use winapi::{

--- a/tests/dont_panic.rs
+++ b/tests/dont_panic.rs
@@ -94,3 +94,14 @@ fn function_exists_module() {
 
     dbg!(SetWindowCompositionAttribute::exists());
 }
+
+mod test {
+    use super::*;
+    // Don't error, even if we redefine Result
+    type Result = core::result::Result<(), ()>;
+    #[dll("user32.dll")]
+    extern "system" {
+        #[allow(non_snake_case)]
+        pub fn SetWindowCompositionAttribute(h_wnd: HWND, data: *mut WINDOWCOMPOSITIONATTRIBDATA) -> BOOL;
+    }
+}


### PR DESCRIPTION
Currently, if `Result` is redefined in the same context `#[dll]` is used, it will cause a compiler error:

```
error[E0107]: wrong number of type arguments: expected 1, found 2
   --> src/lib.rs:4:1
    |
4   | #[dll("user32.dll")]
    | ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
    |
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

To avoid this, we reexport `Result` from our crate, and access it through our crate name.

We don't use it through `std` to avoid cases where std might be renamed (unsure if it can happen, but better safe than sorry).