### PR TITLE
Loadlibraryex args

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,18 @@ fn rtl_get_version_exists() -> bool {
     rtl_get_version::exists()
 }
 ```
+
+### Pass flags to the underlying LoadLibraryExW call
+
+```rust
+use windows_dll::*;
+#[dll("ntdll.dll", LOAD_LIBRARY_SEARCH_SYSTEM32)]
+extern "system" {
+    #[link_name = "RtlGetVersion"]
+    fn rtl_get_version(lp_version_information: *mut OSVERSIONINFOW) -> NTSTATUS;
+}
+
+fn rtl_get_version_exists() -> bool {
+    rtl_get_version::exists()
+}
+```

--- a/codegen/src/windows_dll_impl.rs
+++ b/codegen/src/windows_dll_impl.rs
@@ -7,7 +7,8 @@ use syn::{
     Ident,
     Lit,
     LitInt,
-    LitStr,
+    Expr,
+    ExprLit,
     ItemForeignMod,
     ForeignItem,
     ForeignItemFn,
@@ -16,22 +17,49 @@ use syn::{
     Meta,
     NestedMeta,
     ReturnType,
+    punctuated::Punctuated,
+    token::Comma,
+    parse::Parser,
+    spanned::Spanned,
 };
 use quote::quote;
 use proc_macro_crate::crate_name;
 
 pub fn parse_windows_dll(metadata: TokenStream, input: TokenStream) -> Result<proc_macro2::TokenStream> {
-    let dll_name = parse_dll_name(metadata)?;
-    let functions = parse_extern_block(&dll_name, input)?;
+    let (dll_name, load_library_ex_flags) = parse_dll_name(metadata)?;
+    let functions = parse_extern_block(&dll_name, load_library_ex_flags.as_ref(), input)?;
     Ok(functions)
 }
 
-pub fn parse_dll_name(metadata: TokenStream) -> Result<String> {
-    let dll_name: LitStr = parse(metadata)?;
-    Ok(dll_name.value())
+/// Extract the arguments from the #[dll] macro.
+pub fn parse_dll_name(metadata: TokenStream) -> Result<(String, Option<Expr>)> {
+
+    // Our arguments take the form of `LitStr[, Expr]?`, where the first argument
+    // is the dll name, and the second arg is a flag to pass to LoadLibraryExW.
+    // The easiest way to represent this is with a Punctuated list of expr,
+    // which we will limit to two elements manually.
+    let parser = Punctuated::<Expr, Comma>::parse_terminated;
+    let args: Punctuated<Expr, Comma> = parser.parse(metadata)?;
+
+    // Extract dll name
+    let mut args_it = args.clone().into_iter();
+    let dll = match args_it.next().unwrap() {
+        Expr::Lit(ExprLit { lit: Lit::Str(s), .. }) => s.value(),
+        expr => return Err(syn::Error::new(expr.span(), "DLL name must be a string.")),
+    };
+
+    // Extract the library args (if they exist).
+    let load_library_args = args_it.next();
+
+    // Ensure there aren't any extra flags afterwards.
+    if args_it.next().is_some() {
+        return Err(syn::Error::new(args.span(), "Too many arguments passed to dll macro."));
+    }
+
+    Ok((dll, load_library_args))
 }
 
-pub fn parse_extern_block(dll_name: &str, input: TokenStream) -> Result<proc_macro2::TokenStream> {
+pub fn parse_extern_block(dll_name: &str, load_library_ex_flags: Option<&Expr>, input: TokenStream) -> Result<proc_macro2::TokenStream> {
     let crate_name = crate_name("windows-dll").unwrap_or_else(|_| "windows_dll".to_string());
     let crate_name = Ident::new(&crate_name, Span::call_site());
 
@@ -99,21 +127,33 @@ pub fn parse_extern_block(dll_name: &str, input: TokenStream) -> Result<proc_mac
 
                 let wide_dll_name = quote! { (&[#(#wide_dll_name),*]).as_ptr() };
 
+                // Generate the flags to pass to the load_library_ex function.
+                // Defaulting to 0 will make LoadLibraryExW behave like
+                // LoadLibrary, according to the docs:
+                // > If no flags are specified, the behavior of this function is
+                // > identical to that of the LoadLibrary function.
+                // https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw
+                let flags = if let Some(expr) = load_library_ex_flags {
+                    quote! { #expr }
+                } else {
+                    quote! { 0 }
+                };
+
                 let func_ptr = match link_attr {
                     Some(Link::Ordinal(ordinal)) => quote! {
-                        load_dll_proc_ordinal(#dll_name, #crate_name::Proc::Ordinal(#ordinal), #wide_dll_name, #ordinal)
+                        load_dll_proc_ordinal_ex(#dll_name, #crate_name::Proc::Ordinal(#ordinal), #wide_dll_name, #ordinal, #flags)
                     },
                     Some(Link::Name(name)) => {
                         let name_lpcstr = name.as_bytes().iter().map(|c| *c as i8).chain(once(0));
                         quote! {
-                            load_dll_proc_name(#dll_name, #crate_name::Proc::Name(#name), #wide_dll_name, (&[#(#name_lpcstr),*]).as_ptr())
+                            load_dll_proc_name_ex(#dll_name, #crate_name::Proc::Name(#name), #wide_dll_name, (&[#(#name_lpcstr),*]).as_ptr(), #flags)
                         }
                     },
                     _ => {
                         let name = ident.to_string();
                         let name_lpcstr = name.as_bytes().iter().map(|c| *c as i8).chain(once(0));
                         quote! {
-                            load_dll_proc_name(#dll_name, #crate_name::Proc::Name(#name), #wide_dll_name, (&[#(#name_lpcstr),*]).as_ptr())
+                            load_dll_proc_name_ex(#dll_name, #crate_name::Proc::Name(#name), #wide_dll_name, (&[#(#name_lpcstr),*]).as_ptr(), #flags)
                         }
                     },
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,24 +3,53 @@ pub use {
     once_cell,
 };
 
+pub use winapi::um::libloaderapi::{
+    DONT_RESOLVE_DLL_REFERENCES,
+    LOAD_IGNORE_CODE_AUTHZ_LEVEL,
+    LOAD_LIBRARY_AS_DATAFILE,
+    LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE,
+    LOAD_LIBRARY_AS_IMAGE_RESOURCE,
+    LOAD_LIBRARY_SEARCH_APPLICATION_DIR,
+    LOAD_LIBRARY_SEARCH_DEFAULT_DIRS,
+    LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR,
+    LOAD_LIBRARY_SEARCH_SYSTEM32,
+    LOAD_LIBRARY_SEARCH_USER_DIRS,
+    LOAD_WITH_ALTERED_SEARCH_PATH,
+    LOAD_LIBRARY_REQUIRE_SIGNED_TARGET,
+    LOAD_LIBRARY_SAFE_CURRENT_DIRS,
+};
+
 use winapi::{
     shared::{
-        minwindef::{WORD, FARPROC},
+        minwindef::{WORD, FARPROC, DWORD},
     },
     um::winnt::{LPCSTR, LPCWSTR},
+    um::winuser::MAKEINTRESOURCEA,
 };
 
 #[inline]
 pub unsafe fn load_dll_proc_ordinal(name: &'static str, proc: Proc, name_lpcwstr: LPCWSTR, proc_ordinal: WORD) -> Result<FARPROC, Error> {
-    use winapi::um::winuser::MAKEINTRESOURCEA;
-
-    load_dll_proc_name(name, proc, name_lpcwstr, MAKEINTRESOURCEA(proc_ordinal))
+    load_dll_proc_name_ex(name, proc, name_lpcwstr, MAKEINTRESOURCEA(proc_ordinal), 0)
 }
+
 #[inline]
 pub unsafe fn load_dll_proc_name(name: &'static str, proc: Proc, name_lpcwstr: LPCWSTR, proc_name: LPCSTR) -> Result<FARPROC, Error> {
-    use winapi::um::libloaderapi::{LoadLibraryW, GetProcAddress};
+    load_dll_proc_name_ex(name, proc, name_lpcwstr, proc_name, 0)
+}
 
-    let library = LoadLibraryW(name_lpcwstr);
+
+#[doc(hidden)]
+#[inline]
+pub unsafe fn load_dll_proc_ordinal_ex(name: &'static str, proc: Proc, name_lpcwstr: LPCWSTR, proc_ordinal: WORD, flags: DWORD) -> Result<FARPROC, Error> {
+    load_dll_proc_name_ex(name, proc, name_lpcwstr, MAKEINTRESOURCEA(proc_ordinal), flags)
+}
+
+#[doc(hidden)]
+#[inline]
+pub unsafe fn load_dll_proc_name_ex(name: &'static str, proc: Proc, name_lpcwstr: LPCWSTR, proc_name: LPCSTR, flags: DWORD) -> Result<FARPROC, Error> {
+    use winapi::um::libloaderapi::{LoadLibraryExW, GetProcAddress};
+
+    let library = LoadLibraryExW(name_lpcwstr, std::ptr::null_mut(), flags);
     if library.is_null() {
         return Err(Error::Library(name));
     }
@@ -52,6 +81,7 @@ pub enum Proc {
     Name(&'static str),
     Ordinal(u16),
 }
+
 impl core::fmt::Display for Proc {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {


### PR DESCRIPTION
Allows passing arguments to the underlying LoadLibraryEx function.

This can be used to, for instance, limit the library search to certain folders (e.g. LOAD_LIBRARY_SEARCH_SYSTEM32), or to ensure the loaded library has a valid signature (e.g. LOAD_LIBRARY_REQUIRE_SIGNED_TARGET).

The list of flags that can be passed can be found at https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw .


Example:

```rust
#[dll("ntdll.dll", LOAD_LIBRARY_SEARCH_SYSTEM32)]
extern "system" {
    #[link_name = "RtlGetVersion"]
    fn rtl_get_version(lp_version_information: *mut OSVERSIONINFOW) -> NTSTATUS;
}
```