### PR TITLE
deps: move from windows to windows-sys, updating to 0.45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = ["windows", "win32", "dll", "macro", "ffi"]
 categories = ["development-tools::ffi", "external-ffi-bindings", "api-bindings", "os::windows-apis"]
 
 [features]
-default = ["winapi"]
+default = ["windows"]
 
 [dependencies]
 windows-dll-codegen = { version = "0.4.0", path = "codegen" }
@@ -27,7 +27,8 @@ thiserror = "1"
 once_cell = "1"
 
 [dependencies.windows]
-version = ">= 0.33, <= 0.35"
+package = "windows-sys"
+version = "0.45"
 optional = true
 features = [
     "Win32_Foundation",

--- a/examples/dark_mode.rs
+++ b/examples/dark_mode.rs
@@ -138,7 +138,7 @@ mod platform {
 #[cfg(feature = "windows")]
 mod platform {
     use super::*;
-    use windows::Win32::Foundation::{BOOL, HWND, NTSTATUS};
+    use windows::Win32::Foundation::{BOOL, HWND, NTSTATUS, STATUS_SUCCESS, TRUE};
 
     type DWORD = u32;
     type ULONG = u32;
@@ -178,7 +178,7 @@ mod platform {
             };
             let status = RtlGetVersion(&mut version_info);
 
-            if status.is_ok()
+            if status == STATUS_SUCCESS
                 && version_info.dwMajorVersion == 10
                 && version_info.dwMinorVersion == 0
             {
@@ -195,7 +195,7 @@ mod platform {
     });
 
     pub fn dark_dwm_decorations(minifb_hwnd: *mut c_void, enable_dark_mode: bool) -> bool {
-        let hwnd = HWND(minifb_hwnd as _);
+        let hwnd = minifb_hwnd as _;
 
         #[allow(non_snake_case)]
         type WINDOWCOMPOSITIONATTRIB = u32;
@@ -228,8 +228,7 @@ mod platform {
                 };
 
                 let status = SetWindowCompositionAttribute(hwnd, &mut data);
-
-                status.as_bool()
+                status == TRUE
             }
         } else {
             false

--- a/tests/call.rs
+++ b/tests/call.rs
@@ -58,6 +58,7 @@ mod platform {
 mod platform {
     use super::*;
     pub use windows::Win32::Foundation::NTSTATUS;
+    use windows::Win32::Foundation::STATUS_SUCCESS;
 
     pub type ULONG = u32;
     pub type WCHAR = u16;
@@ -76,7 +77,7 @@ mod platform {
 
             let status = RtlGetVersion(&mut vi as _)?;
 
-            if status.is_ok() {
+            if status == STATUS_SUCCESS {
                 dbg!(vi.dwBuildNumber);
                 Ok(())
             } else {


### PR DESCRIPTION
`windows-sys` is faster to compile and updated less often, which is nice for libraries.

To be backward-compatible I kept the feature name but I can easily change it if you wish.